### PR TITLE
[Feature] Switch workflow to tags/versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,28 +1,46 @@
-name: Build GH Pages 
+name: Build GitHub Pages
 on:
   push:
-    branches:
-      - master 
+    tags:
+      - 'v*'
+  workflow_dispatch:
 permissions:
   contents: write
+  pages: write
+  id-token: write
+ 
 jobs:
-  deploy:
+  build_mkdocs:
     runs-on: ubuntu-latest
+ 
     steps:
-      - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache 
-          restore-keys: |
-            mkdocs-material-
+          python-version: 3.9
       - run: pip install -r requirements.txt 
       - run: mkdocs gh-deploy --force
+ 
+  deploy_mkdocs:
+    needs: build_mkdocs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml.bak
+++ b/.github/workflows/gh-pages.yml.bak
@@ -1,0 +1,28 @@
+name: Build GH Pages 
+on:
+  push:
+    branches:
+      - master 
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache 
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install -r requirements.txt 
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
## 📃 Description

This PR switches the workflow to be based on tags so not every push will build a new site. As for using the action to build and deploy

## 🪵 Changelog

### ✏️ Changed

- `gh-pages.yml` to be triggers on tags
- `gh-pages.yml` to be completed build and deploy